### PR TITLE
Move LS2088A results to production

### DIFF
--- a/jenkins-script.sh
+++ b/jenkins-script.sh
@@ -47,7 +47,7 @@ generate_submit_tests() {
     --build-number "${GIT_DESCRIBE}" \
     --lava-server "${LAVA_SERVER}" \
     --qa-server https://qa-reports.linaro.org \
-    --qa-server-team staging-lkft \
+    --qa-server-team "${QA_TEAM}" \
     --qa-server-project "${QA_PROJECT}" \
     --test-plan "${LKFT_TEST_PLAN}"
   set +x
@@ -87,6 +87,7 @@ create_vars_for_machine() {
   ROOTFS_PUB_DEST="${ROOTFS_RELEASE_PUB_DEST}/${MACHINE_PUB_DEST}/${ROOTFS_BUILDNR_PUB_DEST}"
   GCC_VER_PUB_DEST="gcc-8"
   KERNEL_NAME=Image
+  QA_TEAM=staging-lkft
   QA_PROJECT="linux-mainline-oe"
   LKFT_TEST_PLAN="lkft-sanity"
   DTB_FILENAME=

--- a/jenkins-script.sh
+++ b/jenkins-script.sh
@@ -191,6 +191,7 @@ create_vars_for_machine() {
       LAVA_SERVER=lavalab.nxp.com
       BOOT_OS_PROMPT=
       LKFT_TEST_PLAN="lkft-full"
+      QA_TEAM=lkft
       ;;
     am57xx-evm | qemu_arm)
       # am57xx-evm


### PR DESCRIPTION
With this, we should start seeing NXP LS2088A results appear in the Stable RC's (production) reports.